### PR TITLE
Fix --version flag in published code. Resolves #25.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,4 @@
 {
   "presets": ["@babel/preset-typescript"],
-  "plugins": [
-    [
-      "@babel/plugin-syntax-import-attributes",
-      { "deprecatedAssertSyntax": false },
-    ],
-  ],
+  "plugins": ["@babel/plugin-syntax-import-attributes"],
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,9 @@
 {
   "presets": ["@babel/preset-typescript"],
+  "plugins": [
+    [
+      "@babel/plugin-syntax-import-attributes",
+      { "deprecatedAssertSyntax": false },
+    ],
+  ],
 }

--- a/.changeset/loud-berries-change.md
+++ b/.changeset/loud-berries-change.md
@@ -1,0 +1,5 @@
+---
+"@baseplate-sdk/cli": patch
+---
+
+Fix --version flag in published code

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@babel/core": "^7.23.7",
     "@babel/eslint-parser": "^7.23.3",
+    "@babel/plugin-syntax-import-attributes": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ devDependencies:
   '@babel/eslint-parser':
     specifier: ^7.23.3
     version: 7.23.3(@babel/core@7.23.7)(eslint@8.56.0)
+  '@babel/plugin-syntax-import-attributes':
+    specifier: ^7.23.3
+    version: 7.23.3(@babel/core@7.23.7)
   '@babel/preset-typescript':
     specifier: ^7.23.3
     version: 7.23.3(@babel/core@7.23.7)
@@ -1396,6 +1399,16 @@ packages:
 
   /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.7):
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
+  /@babel/plugin-syntax-import-attributes@7.23.3(@babel/core@7.23.7):
+    resolution: {integrity: sha512-pawnE0P9g10xgoP7yKr6CK63K2FMsTE+FZidZO/1PwRdzmAPVs+HS1mAURUsgaoxammTJvULUdIkEK0gOcU2tA==}
+    engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { deploy, downloadCiConfig } from "./js-api/js-api";
 import { DownloadCiConfigArgs } from "./js-api/ci-config";
+import packageJson from "../package.json" with { type: "json" };
 
 const baseplateToken = process.env.BASEPLATE_TOKEN;
 
@@ -91,6 +92,7 @@ yargs(hideBin(process.argv))
       });
     },
   )
+  .version(packageJson.version)
   .demandCommand(1)
   .scriptName("baseplate")
   .parse();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "moduleResolution": "node",
     "outDir": "lib",
     "target": "ES2022",
-    "declaration": true
+    "declaration": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
See #25. The problem seems related to the package.json not being copied over by at least pnpm when baseplate cli is installed globally